### PR TITLE
Convert into `pt-os-dummy-packages`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# pt-os
+# pt-os-dummy-packages
 
-This package is a dummy package that depends on all of the packages that are installed on pi-topOS on top of Raspberry Pi OS.
+This Debian source package builds multiple binary packages that serve to simplify the organisation and structure of packages in pi-topOS.
 
 It is used as a convenient way of installing all of the component parts required for pi-topOS, and smoothly handling changes in packages during system updates.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-pt-os (3.0.8) buster; urgency=medium
+pt-os-dummy-packages (4.0.0) buster; urgency=medium
 
-  * Add xprintidle as dependency
+  * Rename package
+  * Build all pi-topOS dummy/light packages from this repo
 
- -- pi-top <deb-maintainers@pi-top.com>  Thu, 22 Apr 2021 22:07:12 +0000
+ -- pi-top <deb-maintainers@pi-top.com>  Wed, 05 May 2021 11:20:48 +0000
 
 pt-os (3.0.7) buster; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -84,7 +84,7 @@ Depends: ${misc:Depends},
  zip,
  zsh,
 Description: pi-topOS Development Support
- This meta package contains the files and dependencies required
+ This metapackage contains the files and dependencies required
  to install and configure pi-topOS' development-related
  components.
 
@@ -98,7 +98,7 @@ Depends:
 # (only suggested by device manager to support headless configurations)
  xprintidle,
 Description: pi-topOS Development
- This meta package contains dependencies required to install and configure
+ This metapackage contains dependencies required to install and configure
  pi-topOS' low-level device-related components.
 
 Package: pt-ui
@@ -107,7 +107,7 @@ Depends: ${misc:Depends},
  pt-plym-splash,
  pt-ui-mods,
 Description: pi-topOS UI
- This meta package contains the files and dependencies required
+ This metapackage contains the files and dependencies required
  to install and configure pi-topOS' UI-related components.
 
 Package: pt-user-libs
@@ -126,4 +126,4 @@ Recommends:
 # Optional text-to-speech library
  python3-pt-speech,
 Description: pi-topOS User Libraries
- This meta package contains optional libraries (primarily Python) for pi-topOS
+ This metapackage contains optional libraries (primarily Python) for pi-topOS

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: pt-os
+Source: pt-os-dummy-packages
 Section: utils
 Priority: optional
 Maintainer: pi-top <deb-maintainers@pi-top.com>
@@ -36,3 +36,94 @@ Recommends:
  pt-web-portal,
 Description: pi-topOS top-level dummy package
  The root package of pi-topOS modifications to Raspbian.
+
+Package: pt-apps
+Architecture: all
+Depends: ${misc:Depends},
+# Disk Usage Analyzer
+Recommends: baobab,
+# Keep display alive
+ caffeine,
+ chromium-browser,
+# VS Code
+ code,
+ gimp,
+# Multi-touch friendly calculator
+ gnome-calculator,
+ htop,
+ libreoffice-pi,
+ libreoffice-common,
+ imagemagick,
+ minecraft-pi,
+ mtpaint,
+ mu-editor,
+ pt-about,
+ pt-coder,
+ pt-settings,
+ python-games,
+ python3-minecraftpi,
+ realvnc-vnc-viewer,
+ scratch3,
+ smartsim,
+ sonic-pi,
+ touche,
+ vlc,
+Description: pi-topOS Applications
+ This package contains the files and dependencies required
+ to install and configure pi-topOS' GUI applications.
+
+Package: pt-dev
+Architecture: all
+Depends: ${misc:Depends},
+ asciinema,
+ barrier,
+ p7zip-full,
+ pt-system-tools,
+ silversearcher-ag,
+ squashfs-tools,
+ zip,
+ zsh,
+Description: pi-topOS Development Support
+ This meta package contains the files and dependencies required
+ to install and configure pi-topOS' development-related
+ components.
+
+Package: pt-devices
+Architecture: all
+Depends:
+ ${misc:Depends},
+ pt-device-manager,
+ python3-pitop,
+# Recommend screen blanking dependency
+# (only suggested by device manager to support headless configurations)
+ xprintidle,
+Description: pi-topOS Development
+ This meta package contains dependencies required to install and configure
+ pi-topOS' low-level device-related components.
+
+Package: pt-ui
+Architecture: all
+Depends: ${misc:Depends},
+ pt-plym-splash,
+ pt-ui-mods,
+Description: pi-topOS UI
+ This meta package contains the files and dependencies required
+ to install and configure pi-topOS' UI-related components.
+
+Package: pt-user-libs
+Architecture: all
+Depends:
+ ${misc:Depends},
+# pi-top Python SDK + all dependencies
+ python3-pitop-full,
+# pi-top Python SDK migration support
+ python3-pitop-migr,
+Recommends:
+# Software render for pi-top [4] OLED miniscreen
+ python3-luma-emulator,
+# Useful for graphing
+ python3-matplotlib,
+# Optional text-to-speech library
+ python3-pt-speech,
+Description: pi-topOS User Libraries
+ This meta package contains optional libraries (primarily Python) for pi-topOS

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: pt-os
+Upstream-Name: pt-os-dummy-packages
 Source: https://pi-top.com/
 Upstream-Contact: deb-maintainers@pi-top.com
 

--- a/debian/pt-apps.install
+++ b/debian/pt-apps.install
@@ -1,0 +1,1 @@
+src/*   /usr/bin/

--- a/debian/pt-apps.lintian-overrides
+++ b/debian/pt-apps.lintian-overrides
@@ -1,0 +1,1 @@
+pt-apps: binary-without-manpage

--- a/debian/pt-apps.postinst
+++ b/debian/pt-apps.postinst
@@ -1,0 +1,32 @@
+#!/bin/bash
+###############################################################
+#                Unofficial 'Bash strict mode'                #
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/  #
+###############################################################
+set -euo pipefail
+IFS=$'\n\t'
+###############################################################
+
+
+case "$1" in
+\
+  configure)
+      # Clean up removed `pt-portal` on startup if it exists
+      old_portal_file="/home/pi/.config/autostart/pt-portal.desktop"
+      [[ -f "${old_portal_file}" ]] && rm "${old_portal_file}"
+  ;;
+
+\
+  abort-upgrade | abort-remove | abort-deconfigure)
+  ;;
+
+\
+  *)
+  echo "postinst called with unknown argument \`$1'" >&2
+  exit 1
+  ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/src/run-sonic-pi-server
+++ b/src/run-sonic-pi-server
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "#################################################"
+echo "##   'run-sonic-pi-server' is now deprecated   ##"
+echo "##        Please use 'sonic-pi-server'         ##"
+echo "#################################################"
+
+exit 1

--- a/src/sonic-pi-server
+++ b/src/sonic-pi-server
@@ -1,0 +1,41 @@
+#!/bin/bash
+###############################################################
+#                Unofficial 'Bash strict mode'                #
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/  #
+###############################################################
+set -euo pipefail
+IFS=$'\n\t'
+###############################################################
+
+logFile="/tmp/sonic-pi-server-log.txt"
+
+try_start_server() {
+	local sonicPiServerPath="${1}"
+
+	if [[ -f "${sonicPiServerPath}" ]]; then
+		echo "Sonic Pi server found: ${sonicPiServerPath}"
+		echo "Log file: ${logFile}"
+
+		cmd="/usr/bin/ruby -E utf-8 ${sonicPiServerPath}"
+		echo
+		echo "Running Sonic Pi server in the background..."
+		echo -e "\t${cmd}"
+		echo
+		echo
+		echo "Press Ctrl+C at any time to stop."
+		echo
+		echo "Please wait for Sonic Pi Server to start..."
+		echo
+		/usr/bin/ruby -E utf-8 "${sonicPiServerPath}" 2>&1 | tee "${logFile}" | ag "Sonic Pi Server successfully booted."
+		return 0
+	else
+		echo "Sonic Pi server not found at path: ${sonicPiServerPath}"
+		return 1
+	fi
+}
+
+# Try /opt first (Sonic Pi's "sonic-pi" package preferred to RPi's "sonic-pi-server" package)
+if ! try_start_server "/opt/sonic-pi/app/server/ruby/bin/sonic-pi-server.rb" &&
+	! try_start_server "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"; then
+	echo "The Sonic Pi server application could not be found. You may need to check for updates or re-install Sonic Pi"
+fi


### PR DESCRIPTION
Build all dummy packages from one source.
Other repos can be deprecated.
Need to check that version is later than all of the packages that are built to ensure that they upgrade.